### PR TITLE
feat/ add player.roundCount on event gameLost and in getter getStatus

### DIFF
--- a/packages/hardhat/contracts/LfgGame/GameImplementation.sol
+++ b/packages/hardhat/contracts/LfgGame/GameImplementation.sol
@@ -465,8 +465,7 @@ contract GameImplementation {
             uint256,
             uint256,
             bool,
-            bool,
-            uint256
+            bool
         )
     {
         // uint256 balance = address(this).balance;
@@ -483,8 +482,7 @@ contract GameImplementation {
             houseEdge,
             creatorEdge,
             contractPaused,
-            gameInProgress,
-            player.roundCount,
+            gameInProgress
         );
     }
 


### PR DESCRIPTION
Here is my PR proposal,

I added player.roundCount in the gameLost event and in the getStatus getter. 

However, I don't see where to reset it to zero. 